### PR TITLE
Updated js to new way of setting callbackURL in Auth0Lock 10.x.x

### DIFF
--- a/hello_auth/templates/hello_auth/base.html
+++ b/hello_auth/templates/hello_auth/base.html
@@ -4,22 +4,20 @@
     <meta charset="UTF-8">
     <title>Title</title>
 
-    <script src="https://cdn.auth0.com/js/lock-9.1.min.js"></script>
+    <script src="http://cdn.auth0.com/js/lock/10.2.2/lock.min.js"></script>
     <script type="text/javascript">
-        var lock = new Auth0Lock('{{ AUTH0_CLIENT_ID }}', '{{ AUTH0_DOMAIN }}');
-
-        function signin() {
-            lock.show({
-                callbackURL: '{{ AUTH0_CALLBACK_URL }}',
-                responseType: 'code',
-                authParams: {
-                    scope: 'openid profile'
-                }
-            });
+      var lock = new Auth0Lock('{{ AUTH0_CLIENT_ID }}', '{{ AUTH0_DOMAIN }}', {
+        auth: {
+          redirectUrl: '{{ AUTH0_CALLBACK_URL }}',
+          responseType: 'code',
+          params: {
+            scope: 'openid profile'
+          }
         }
-    </script>
+      });
+</script>
 </head>
 <body>
-    <button onclick="window.signin();">Login</button>
+    <button onclick="lock.show();">Login</button>
 </body>
 </html>


### PR DESCRIPTION
Hi, 

Thanks for making django-auth0. We're finding it really useful, so I wanted to update your example with the latest version of [Auth0's Lock](https://github.com/auth0/lock). The constructor expects the callback URL to be provided a little differently.

The JS in this PR is identical to what's given in the official Auth0 docs (except that 'profile' has been added to the scope):
https://auth0.com/docs/quickstart/webapp/python

Thanks
